### PR TITLE
Add README for Kris Gracia's portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# clearlinekris.github.io
+
+> **Official portfolio for Kris Gracia — Cannabis Compliance Strategist, AI Automation Architect, and Founder of ClearLine.**
+
+🌐 **Live site:** [clearlinekris.github.io](https://clearlinekris.github.io)
+
+---
+
+## About This Repo
+
+This is the source code for Kris Gracia's personal and professional portfolio — the digital front door to **ClearLine**, a compliance consulting platform built at the intersection of cannabis regulation, AI-enhanced automation, and operational precision.
+
+If you're here, you're probably a potential client, collaborator, or fellow builder navigating the increasingly complex world of cannabis compliance.
+
+---
+
+## What You'll Find
+
+- **`index.html`** — The main portfolio page, hand-crafted with intention
+- **`styles.css`** — Clean, branded styling
+- **`favicon.png`** — The mark of ClearLine
+- **`Codex_Horizon_Regolith_Mapping.md`** — Internal knowledge architecture documentation
+- **`.github/`** — Workflow and automation configuration
+
+---
+
+## About ClearLine
+
+**ClearLine** is a boutique compliance consulting firm specializing in:
+
+- 🌿 **METRC compliance** — seed-to-sale tracking, audit prep, and data reconciliation
+- 🤖 **AI-enhanced operations** — intelligent agents for regulatory workflows
+- 📋 **Cannabis waste & packaging audits** — documentation-ready, inspection-proof
+- 📊 **Data extraction & ETL pipelines** — turning raw compliance data into actionable intelligence
+
+ClearLine operates on one core principle: *compliance doesn't have to be chaos.*
+
+---
+
+## About Kris
+
+Kris is a METRC Specialist and Compliance Strategist with years of hands-on experience across Colorado's cannabis industry — from dispensary operations to multi-state operator (MSO) environments. A builder at heart, Kris combines deep regulatory expertise with advanced AI tooling to create systems that actually work in the real world.
+
+Also known as **Kris in the Loop** — always at the intersection of human judgment and automated systems. Proudly a **Human with a K**: the irreplaceable, carbon-based variable in every compliance workflow.
+
+**Stack:** Python · JavaScript · YAML · SQL · Obsidian · GitHub · Google Workspace · Claude/Copilot/Gemini
+
+---
+
+## Contact & Connect
+
+- 📧 Reach out via the portfolio site
+- 🐙 GitHub: [@clearlineKris](https://github.com/clearlineKris)
+
+---
+
+*Built in Denver, Colorado. Navigating penumbrant ambiguity — one commit at a time.*


### PR DESCRIPTION
This README.md file serves as the official portfolio for Kris Gracia, outlining the services of ClearLine and providing contact information.